### PR TITLE
fix adwaita not found

### DIFF
--- a/pkgs/modules/gui-base.nix
+++ b/pkgs/modules/gui-base.nix
@@ -1,5 +1,10 @@
-{ config, lib, pkgs, sloth, ... }:
 {
+  config,
+  lib,
+  pkgs,
+  sloth,
+  ...
+}: {
   config = {
     dbus.policies = {
       "${config.flatpak.appId}" = "own";
@@ -40,12 +45,12 @@
       ];
       env = {
         XDG_DATA_DIRS = lib.makeSearchPath "share" [
-          pkgs.adwaita-icon-theme
+          pkgs.gnome.adwaita-icon-theme
           pkgs.shared-mime-info
         ];
         XCURSOR_PATH = lib.concatStringsSep ":" [
-          "${pkgs.adwaita-icon-theme}/share/icons"
-          "${pkgs.adwaita-icon-theme}/share/pixmaps"
+          "${pkgs.gnome.adwaita-icon-theme}/share/icons"
+          "${pkgs.gnome.adwaita-icon-theme}/share/pixmaps"
         ];
       };
     };


### PR DESCRIPTION
In recent versions, `pkgs.adwaita-icon-theme` is now `pkgs.`[gnome.adwaita-icon-theme](https://search.nixos.org/packages?channel=24.05&from=0&size=50&sort=relevance&type=packages&query=adwaita-icon-theme).